### PR TITLE
Added auth type as instance principal for OCI

### DIFF
--- a/ansible/roles/lern-data-products-deploy/defaults/main.yml
+++ b/ansible/roles/lern-data-products-deploy/defaults/main.yml
@@ -4,7 +4,7 @@ spark_output_temp_dir: /mount/data/analytics/tmp/
 
 bucket: "telemetry-data-store"
 secor_bucket: "telemetry-data-store"
-dp_object_store_type: "azure"
+dp_object_store_type: "{{ cloud_service_provider }}"
 dp_raw_telemetry_backup_location: "unique/raw/"
 dp_storage_key_config: "azure_storage_key"
 dp_storage_secret_config: "azure_storage_secret"

--- a/ansible/roles/lern-data-products-deploy/tasks/main.yml
+++ b/ansible/roles/lern-data-products-deploy/tasks/main.yml
@@ -5,6 +5,11 @@
   tags:
     - always
 
+- name: Apply environment
+  apply:
+    environment:
+      OCI_CLI_AUTH: "instance_principal" # Used only for OCI
+
 - name: Ensure oci oss bucket exists
   command: "/home/{{analytics_user}}/bin/oci os bucket get --name {{ bucket }}"
   register: check_bucket


### PR DESCRIPTION
dp_object_store_type was hardcoded as azure. Changed it to take value from cloud_service_provider.
Applied instance principal authentication for oci bucket tasks.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update